### PR TITLE
📝Update bug report link in CONTRIBUTING document

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -15,7 +15,7 @@ Types of Contributions
 Report Bugs
 ~~~~~~~~~~~
 
-Report bugs at https://github.com/MoshiBin/otel-cli/issues.
+Report bugs at https://github.com/dell/opentelemetry-cli/issues.
 
 If you are reporting a bug, please include:
 


### PR DESCRIPTION
I noticed in reading the `CONTRIBUTING` document that one of the URLs looked incorrect, and indeed, doesn't seem to be valid.  I presume it should point at the current repository location, like the other link just below it.  (If I am incorrect, please disregard)